### PR TITLE
Fix JSON decoding using custom date formatting strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ jobs:
 
     steps:
     - name: Fetch feedback
-      uses: lukas-ruzicka/testflight-feedback@1.0.1
+      uses: lukas-ruzicka/testflight-feedback@1.0.3
       env:
         FASTLANE_SESSION: ${{ secrets.FASTLANE_SESSION }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -166,7 +166,7 @@ jobs:
 
     steps:
     - name: Clear screenshots
-      uses: lukas-ruzicka/testflight-feedback@1.0.1
+      uses: lukas-ruzicka/testflight-feedback@1.0.3
       with:
         clearScreenshotsOnly: true
       env:

--- a/action.js
+++ b/action.js
@@ -1,7 +1,7 @@
 const core = require('./.action/core')
 const exec = require('./.action/exec')
 
-const version = '1.0.1'
+const version = '1.0.3'
 
 core.setCommandEcho(true)
 


### PR DESCRIPTION
### Date encoding format seems to be changed: from UNIX-timestamps it became ISO8601 date format in 2 variants - with or without fractional seconds.

If it was only option without fractional seconds, we could use "vanilla" JSONDecoder's `.iso8601` date decoding strategy.
As long as there are 2 sub-formats, we need to workaround it using `.custom` date decoding strategy and 2 date formatters.